### PR TITLE
Added ability to set a split name at the current index, or at a given index.

### DIFF
--- a/UI/Components/Component.cs
+++ b/UI/Components/Component.cs
@@ -277,6 +277,19 @@ namespace LiveSplit.UI.Components
                 {
                     State.CurrentTimingMethod = TimingMethod.GameTime;
                 }
+                else if (message.StartsWith("setsplitname "))
+                {
+                    int index = Convert.ToInt32(message.Split(new char[] { ' ' }, 3)[1]);
+                    String title = message.Split(new char[] { ' ' }, 3)[2];
+                    State.Run[index].Name = title;
+                    State.Run.HasChanged = true;
+                }
+                else if (message.StartsWith("setcurrentsplitname "))
+                {
+                    String title = message.Split(new char[] { ' ' }, 2)[1];
+                    State.Run[State.CurrentSplitIndex].Name = title;
+                    State.Run.HasChanged = true;
+                }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Added two commands:
setcurrentsplitname \<name>
setsplitname \<index> \<name>

\<name> is the new name of the split.
\<index> is the index of the split to be renamed, uses the same indexes as those returned from the "getsplitindex" command.