### PR TITLE
Fixed Java 7+ client example error

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ import java.net.Socket;
 
 public class MainTest {
 
-	public static void main(String[]){
+	public static void main(String[] args){
     String hostName = "localhost";
 		int portNumber = 16834;
 


### PR DESCRIPTION
String[] variable in main function was missing a name.