### PR TITLE
getcurrenttime: use RealTime if GameTime isn't initialized

### DIFF
--- a/UI/Components/ServerComponent.cs
+++ b/UI/Components/ServerComponent.cs
@@ -280,7 +280,10 @@ namespace LiveSplit.UI.Components
                 }
                 else if (message == "getcurrenttime")
                 {
-                    var time = State.CurrentTime[State.CurrentTimingMethod];
+                    var timingMethod = State.CurrentTimingMethod;
+                    if (timingMethod == TimingMethod.GameTime && !State.IsGameTimeInitialized)
+                        timingMethod = TimingMethod.RealTime;
+                    var time = State.CurrentTime[timingMethod];
                     var response = SplitTimeFormatter.Format(time);
                     clientConnection.SendMessage(response);
                 }


### PR DESCRIPTION
If Game Time isn't initialized `getcurrenttime` will return `0.00` while LiveSplit's timer component will just show Real Time instead. This PR makes the command match the timer component behavior.

I don't know if this would break any existing apps.